### PR TITLE
Add a capturing field sample

### DIFF
--- a/KNConcurrencyHandson/src/nativeMain/kotlin/sample/SampleMain.kt
+++ b/KNConcurrencyHandson/src/nativeMain/kotlin/sample/SampleMain.kt
@@ -12,7 +12,7 @@ fun main() {
     // 2) Frozen State
     // freezeSomeState()
     // failChanges()
-    freezeChildren()
+    // freezeChildren()
 
     // 3) Global State
 //    cantChangeThis()
@@ -28,7 +28,7 @@ fun main() {
 //    captureState()
 //    captureTooMuch()
 //    captureTooMuchAgain()
-//    captureArgs()
+    captureArgs()
 
     // 5) Debugging
 //    ensureNeverFrozenFailNow()


### PR DESCRIPTION
ラムダ式をfreezeするとそのラムダ式がキャプチャする変数も全てfreezeされる挙動の例に、その変数が参照型である場合を追加した。

参照型はきちんとディープコピーしないと`InvalidMutabilityException`が起きることが分かった。
また、`data class`であっても`copy`メソッドはshallow copyしかしないので、deep copyをきちんと行うようにしないと意図しないfreezeを引き起こすことが分かった。